### PR TITLE
Fix group layout 404 error

### DIFF
--- a/Service/src/main/java/org/orthomcl/service/services/GroupLayoutService.java
+++ b/Service/src/main/java/org/orthomcl/service/services/GroupLayoutService.java
@@ -11,13 +11,13 @@ import org.gusdb.wdk.service.service.AbstractWdkService;
 import org.orthomcl.service.core.layout.GroupLayout;
 import org.orthomcl.service.core.layout.GroupLayoutManager;
 
+@Path("/group")
 public class GroupLayoutService extends AbstractWdkService {
 
   @GET
-  @Path("/group/{groupName}/layout")
+  @Path("/{groupName}/layout")
   @Produces(MediaType.APPLICATION_JSON)
   public Response handleRequest(@PathParam("groupName") String groupName) throws Exception {
-
     // get the layout data
     GroupLayoutManager layoutManager = new GroupLayoutManager(getWdkModel());
     GroupLayout layout = layoutManager.getLayout(getSessionUser(), groupName);


### PR DESCRIPTION
This PR fixes a small bug that was causing `GET` requests to `/group/{groupName}/layout` to 404.